### PR TITLE
[BE - API] 즐겨찾는 카테고리 서비스 및 권한 체크 서비스 추가

### DIFF
--- a/api-server/build.gradle
+++ b/api-server/build.gradle
@@ -6,9 +6,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.cloud:spring-cloud-starter-config:3.1.4'
 
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.0'
-
     runtimeOnly 'com.h2database:h2:1.4.200'
     runtimeOnly 'mysql:mysql-connector-java'
 

--- a/api-server/src/main/java/com/huyeon/superspace/domain/board/controller/BoardWriteController.java
+++ b/api-server/src/main/java/com/huyeon/superspace/domain/board/controller/BoardWriteController.java
@@ -108,7 +108,7 @@ public class BoardWriteController {
     private void checkUpdatePermission(String id, String userEmail, String errorMsg) {
         BoardDto board = boardService.getBoard(id);
         if (isNotAuthor(board.getAuthor(), userEmail)
-                || isNotManager(board.getGroupUrl(), userEmail)) {
+                && isNotManager(board.getGroupUrl(), userEmail)) {
             throw new PermissionDeniedException(errorMsg);
         }
     }

--- a/api-server/src/main/java/com/huyeon/superspace/domain/board/controller/CategoryRestController.java
+++ b/api-server/src/main/java/com/huyeon/superspace/domain/board/controller/CategoryRestController.java
@@ -2,6 +2,7 @@ package com.huyeon.superspace.domain.board.controller;
 
 import com.huyeon.superspace.domain.board.dto.CategoryCreateDto;
 import com.huyeon.superspace.domain.board.dto.CategoryDto;
+import com.huyeon.superspace.domain.board.dto.FavoriteCategoryReq;
 import com.huyeon.superspace.domain.board.service.NewCategoryService;
 import com.huyeon.superspace.global.exception.PermissionDeniedException;
 import com.huyeon.superspace.domain.group.service.NewGroupService;
@@ -21,8 +22,10 @@ public class CategoryRestController {
     private final NewGroupService groupService;
 
     @GetMapping
-    public List<CategoryDto> getCategories(@RequestParam String url) {
-        return categoryService.getCategoryTree(url);
+    public List<CategoryDto> getCategories(
+            @RequestHeader("X-Authorization-Id") String email,
+            @RequestParam String url) {
+        return categoryService.getCategoryTree(email, url);
     }
 
     @PostMapping
@@ -59,5 +62,13 @@ public class CategoryRestController {
         if (groupService.isNotManager(groupUrl, userEmail)) {
             throw new PermissionDeniedException(errorMsg);
         }
+    }
+
+    @PutMapping("/favorite")
+    public void setFavoriteCategory(
+            @RequestHeader("X-Authorization-Id") String email,
+            @RequestBody FavoriteCategoryReq request
+    ) {
+        categoryService.setFavorite(email, request);
     }
 }

--- a/api-server/src/main/java/com/huyeon/superspace/domain/board/document/FavoriteCategory.java
+++ b/api-server/src/main/java/com/huyeon/superspace/domain/board/document/FavoriteCategory.java
@@ -1,0 +1,23 @@
+package com.huyeon.superspace.domain.board.document;
+
+import com.huyeon.superspace.global.model.DocumentAudit;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Document
+public class FavoriteCategory extends DocumentAudit {
+    private String userEmail;
+
+    private String groupUrl;
+
+    private List<String> categoryId;
+}

--- a/api-server/src/main/java/com/huyeon/superspace/domain/board/dto/CategoryDto.java
+++ b/api-server/src/main/java/com/huyeon/superspace/domain/board/dto/CategoryDto.java
@@ -20,6 +20,8 @@ public class CategoryDto {
 
     private CategoryDto parent;
 
+    private boolean favorite;
+
     private List<CategoryDto> children; //읽기용
 
     public CategoryDto(Category category) {

--- a/api-server/src/main/java/com/huyeon/superspace/domain/board/dto/FavoriteCategoryReq.java
+++ b/api-server/src/main/java/com/huyeon/superspace/domain/board/dto/FavoriteCategoryReq.java
@@ -1,0 +1,14 @@
+package com.huyeon.superspace.domain.board.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FavoriteCategoryReq {
+    private String groupUrl;
+    private String categoryId;
+    private boolean set;
+}

--- a/api-server/src/main/java/com/huyeon/superspace/domain/board/repository/FavoriteCategoryRepository.java
+++ b/api-server/src/main/java/com/huyeon/superspace/domain/board/repository/FavoriteCategoryRepository.java
@@ -1,0 +1,10 @@
+package com.huyeon.superspace.domain.board.repository;
+
+import com.huyeon.superspace.domain.board.document.FavoriteCategory;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.Optional;
+
+public interface FavoriteCategoryRepository extends MongoRepository<FavoriteCategory, String> {
+    Optional<FavoriteCategory> findAllByUserEmailAndGroupUrl(String email, String groupUrl);
+}

--- a/api-server/src/main/java/com/huyeon/superspace/domain/board/service/PermissionCheckService.java
+++ b/api-server/src/main/java/com/huyeon/superspace/domain/board/service/PermissionCheckService.java
@@ -1,0 +1,31 @@
+package com.huyeon.superspace.domain.board.service;
+
+import com.huyeon.superspace.domain.board.dto.BoardDto;
+import com.huyeon.superspace.domain.group.repository.NewGroupRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PermissionCheckService {
+    private final NewGroupRepository groupRepository;
+
+    //작성자이거나 관리자일 경우 수정 허용
+    public boolean isGrantAccess(BoardDto boardDto, String userEmail) {
+        return isAuthor(boardDto.getAuthor(), userEmail)
+                || isManager(boardDto.getGroupUrl(), userEmail);
+    }
+
+    private boolean isAuthor(String author, String userEmail) {
+        return author.equals(userEmail);
+    }
+
+    private boolean isManager(String groupUrl, String userEmail) {
+        return groupRepository.findByUrl(groupUrl)
+                .orElseThrow()
+                .getManagers()
+                .contains(userEmail);
+    }
+}

--- a/api-server/src/main/java/com/huyeon/superspace/domain/group/document/Member.java
+++ b/api-server/src/main/java/com/huyeon/superspace/domain/group/document/Member.java
@@ -1,5 +1,6 @@
 package com.huyeon.superspace.domain.group.document;
 
+import com.huyeon.superspace.global.model.DocumentAudit;
 import lombok.*;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.DBRef;
@@ -11,7 +12,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @NoArgsConstructor
 @AllArgsConstructor
 @Document(collection = "members")
-public class Member {
+public class Member extends DocumentAudit {
     @DBRef
     @Indexed(unique = true)
     private Group group;
@@ -22,4 +23,8 @@ public class Member {
     private String nickname;
 
     private String role;
+
+    private int postCount;
+
+    private int commentCount;
 }

--- a/api-server/src/main/java/com/huyeon/superspace/domain/group/dto/MemberDto.java
+++ b/api-server/src/main/java/com/huyeon/superspace/domain/group/dto/MemberDto.java
@@ -19,12 +19,21 @@ public class MemberDto {
 
     private String role;
 
+    private int postCount;
+
+    private int commentCount;
+
+    private String joinDate;
+
     public MemberDto(Member member) {
         id = member.getGroup().getId();
         email = member.getUserEmail();
         nickname = member.getNickname();
         groupUrl = member.getGroup().getUrl();
         role = member.getRole();
+        postCount = member.getPostCount();
+        commentCount = member.getCommentCount();
+        joinDate = member.getCreatedAt().toLocalDate().toString();
     }
 }
 

--- a/api-server/src/main/java/com/huyeon/superspace/domain/group/repository/NewMemberRepository.java
+++ b/api-server/src/main/java/com/huyeon/superspace/domain/group/repository/NewMemberRepository.java
@@ -2,10 +2,12 @@ package com.huyeon.superspace.domain.group.repository;
 
 import com.huyeon.superspace.domain.group.document.Member;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface NewMemberRepository extends MongoRepository<Member, String> {
     Optional<Member> findByGroupIdAndUserEmail(String groupId, String userEmail);
 

--- a/api-server/src/main/java/com/huyeon/superspace/domain/group/service/NewGroupService.java
+++ b/api-server/src/main/java/com/huyeon/superspace/domain/group/service/NewGroupService.java
@@ -109,6 +109,16 @@ public class NewGroupService {
         return memberRepository.findAllByUserEmail(userEmail);
     }
 
+    public MemberDto findByUserEmail(String userEmail, String groupUrl) {
+        String groupById = findGroupByUrl(groupUrl).getId();
+        return memberRepository.findByGroupIdAndUserEmail(groupById, userEmail)
+                .map(MemberDto::new)
+                .orElse(MemberDto.builder()
+                        .id("anonymous")
+                        .nickname("그룹 가입이 필요합니다.")
+                        .build());
+    }
+
     private boolean existsByUrl(String url) {
         return groupRepository.existsByUrl(url);
     }

--- a/api-server/src/main/java/com/huyeon/superspace/global/config/JacksonConfig.java
+++ b/api-server/src/main/java/com/huyeon/superspace/global/config/JacksonConfig.java
@@ -1,46 +1,18 @@
 package com.huyeon.superspace.global.config;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.io.IOException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 
 @Configuration
 public class JacksonConfig {
     @Bean
-    public Module jsonLocalDateTimeMapper() {
-        SimpleModule module = new SimpleModule();
-
-        module.addSerializer(LocalDate.class, new JsonSerializer<>() {
-            @Override
-            public void serialize(LocalDate value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-                gen.writeString(DateTimeFormatter.ofPattern("yyyy-MM-dd").format(value));
-            }
-        });
-
-        module.addSerializer(LocalTime.class, new JsonSerializer<>() {
-            @Override
-            public void serialize(LocalTime value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-                gen.writeString(DateTimeFormatter.ofPattern("kk:mm:ss").format(value));
-            }
-        });
-
-        module.addSerializer(LocalDateTime.class, new JsonSerializer<>() {
-            @Override
-            public void serialize(LocalDateTime value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-                gen.writeString(DateTimeFormatter.ofPattern("yyyy-MM-dd kk:mm:ss").format(value));
-            }
-        });
-
-        return module;
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return objectMapper;
     }
 }

--- a/api-server/src/main/java/com/huyeon/superspace/web/common/dto/SideBarDto.java
+++ b/api-server/src/main/java/com/huyeon/superspace/web/common/dto/SideBarDto.java
@@ -2,6 +2,7 @@ package com.huyeon.superspace.web.common.dto;
 
 import com.huyeon.superspace.domain.board.dto.CategoryDto;
 import com.huyeon.superspace.domain.group.dto.GroupViewDto;
+import com.huyeon.superspace.domain.group.dto.MemberDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +15,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SideBarDto {
+    private MemberDto member;
     private List<GroupViewDto> groups;
     private List<CategoryDto> categories;
 }

--- a/api-server/src/main/java/com/huyeon/superspace/web/common/service/SideBarAndHeaderService.java
+++ b/api-server/src/main/java/com/huyeon/superspace/web/common/service/SideBarAndHeaderService.java
@@ -5,6 +5,7 @@ import com.huyeon.superspace.domain.board.service.NewCategoryService;
 import com.huyeon.superspace.domain.group.document.Member;
 import com.huyeon.superspace.domain.group.dto.GroupDto;
 import com.huyeon.superspace.domain.group.dto.GroupViewDto;
+import com.huyeon.superspace.domain.group.dto.MemberDto;
 import com.huyeon.superspace.domain.group.service.NewGroupService;
 import com.huyeon.superspace.domain.user.repository.UserRepository;
 import com.huyeon.superspace.global.support.CacheUtils;
@@ -74,15 +75,21 @@ public class SideBarAndHeaderService {
     }
 
     private SideBarDto getSideBar(String userEmail, String groupUrl) {
+        MemberDto member = getMemberInfo(userEmail, groupUrl);
         List<GroupViewDto> groups = getGroups(userEmail);
-        List<CategoryDto> categories = getHierarchicalCategories(groupUrl);
+        List<CategoryDto> categories = getHierarchicalCategories(userEmail, groupUrl);
 
         if (categories == null) categories = Collections.emptyList();
 
         return SideBarDto.builder()
+                .member(member)
                 .groups(groups)
                 .categories(categories)
                 .build();
+    }
+
+    private MemberDto getMemberInfo(String userEmail, String groupUrl) {
+        return groupService.findByUserEmail(userEmail, groupUrl);
     }
 
     private List<GroupViewDto> getGroups(String email) {
@@ -93,8 +100,8 @@ public class SideBarAndHeaderService {
                 .collect(Collectors.toList());
     }
 
-    private List<CategoryDto> getHierarchicalCategories(String groupUrl) {
-        return categoryService.getCategoryTree(groupUrl);
+    private List<CategoryDto> getHierarchicalCategories(String email, String groupUrl) {
+        return categoryService.getCategoryTree(email, groupUrl);
     }
 
     public Map<String, Object> getBlankHeaderAndSideBar(String email) {
@@ -105,10 +112,19 @@ public class SideBarAndHeaderService {
     }
 
     public SideBarDto getBlankSideBar(String email) {
+        MemberDto member = getNoneSelectGroupProfile();
         List<GroupViewDto> groups = getGroups(email);
         return SideBarDto.builder()
+                .member(member)
                 .groups(groups)
                 .categories(List.of())
+                .build();
+    }
+
+    private MemberDto getNoneSelectGroupProfile() {
+        return MemberDto.builder()
+                .id("anonymous")
+                .nickname("선택한 그룹이 없습니다.")
                 .build();
     }
 

--- a/api-server/src/main/java/com/huyeon/superspace/web/domain/board/BoardController.java
+++ b/api-server/src/main/java/com/huyeon/superspace/web/domain/board/BoardController.java
@@ -4,6 +4,7 @@ import com.huyeon.superspace.domain.board.dto.BoardDto;
 import com.huyeon.superspace.domain.board.dto.CommentDto;
 import com.huyeon.superspace.domain.board.service.NewBoardService;
 import com.huyeon.superspace.domain.board.service.NewCommentService;
+import com.huyeon.superspace.domain.board.service.PermissionCheckService;
 import com.huyeon.superspace.global.exception.AlreadyExistException;
 import com.huyeon.superspace.domain.group.service.NewGroupService;
 import com.huyeon.superspace.web.annotation.GroupPage;
@@ -23,6 +24,7 @@ public class BoardController {
     private final NewGroupService groupService;
     private final NewBoardService boardService;
     private final NewCommentService commentService;
+    private final PermissionCheckService permissionCheckService;
 
     @GroupPage
     @GetMapping("/{groupUrl}/board/{id}")
@@ -38,6 +40,12 @@ public class BoardController {
         Map<String, Object> response = new HashMap<>();
 
         BoardDto board = boardService.getBoard(id);
+
+        if (permissionCheckService.isGrantAccess(board, userEmail)) {
+            response.put("editable", true);
+        } else {
+            response.put("editable", false);
+        }
 
         String groupId = groupService.findGroupByUrl(groupUrl).getId();
         List<CommentDto> comments = commentService.getCommentInBoard(groupId, userEmail, board.getId(), 0);

--- a/api-server/src/main/java/com/huyeon/superspace/web/domain/board/CategoryController.java
+++ b/api-server/src/main/java/com/huyeon/superspace/web/domain/board/CategoryController.java
@@ -4,7 +4,6 @@ import com.huyeon.superspace.domain.board.dto.BoardDto;
 import com.huyeon.superspace.domain.board.dto.CategoryDto;
 import com.huyeon.superspace.domain.board.service.NewBoardService;
 import com.huyeon.superspace.domain.board.service.NewCategoryService;
-import com.huyeon.superspace.domain.group.service.NewGroupService;
 import com.huyeon.superspace.web.annotation.GroupPage;
 import com.huyeon.superspace.web.annotation.ManagerPage;
 import lombok.RequiredArgsConstructor;
@@ -48,13 +47,13 @@ public class CategoryController {
             @PathVariable String groupUrl
     ) {
         Map<String, Object> response = new HashMap<>();
-        response.put("topCategories", getCategoryTree(groupUrl));
+        response.put("topCategories", getCategoryTree(userEmail, groupUrl));
 
         return response;
     }
 
-    private List<CategoryDto> getCategoryTree(String groupUrl) {
-        return categoryService.getCategoryTree(groupUrl);
+    private List<CategoryDto> getCategoryTree(String email, String groupUrl) {
+        return categoryService.getCategoryTree(email, groupUrl);
     }
 
     @GroupPage


### PR DESCRIPTION
# 즐겨찾는 카테고리 서비스 추가
- 사이드 바에서 사용자가 특정 그룹의 카테고리를 즐겨찾기로 등록하고 확인할 수 있도록 추가
- DB에 favoriteCategory Collection 추가
- 사용자 이메일과 그룹 URL을 통해 해당 Document 획득 가능
- PUT("/api/category/favorite")에 FavoriteCategoryReq DTO에 맞게 요청

# 권한 체크 서비스
- 여러 기능이 권한을 확인하는 과정을 거치기 때문에 따로 분리함
- 게시글 작성자 or 관리자 권한이 있는 사용자만 데이터를 획득할 수 있음
- 없을 시 PermissionDeniedException 발생

## 기타
- JSR310 라이브러리 삭제