### PR TITLE
[FE] 버그 및 부정적 UX 개선

### DIFF
--- a/api-server/src/main/java/com/huyeon/superspace/domain/board/controller/CommentRestController.java
+++ b/api-server/src/main/java/com/huyeon/superspace/domain/board/controller/CommentRestController.java
@@ -4,6 +4,7 @@ import com.huyeon.superspace.domain.board.dto.CommentBoardPreviewDto;
 import com.huyeon.superspace.domain.board.dto.CommentDto;
 import com.huyeon.superspace.domain.board.dto.CommentPreviewDto;
 import com.huyeon.superspace.domain.board.service.NewCommentService;
+import com.huyeon.superspace.global.exception.PermissionDeniedException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -43,6 +44,9 @@ public class CommentRestController {
             @RequestBody CommentDto request
     ) {
         Objects.requireNonNull(request.getBoardId());
+        if (userEmail.equals("CONMOTO_ANONYMOUS_TOKEN")) {
+            throw new PermissionDeniedException("비로그인 댓글 작성시도");
+        }
 
         return commentService.createComment(userEmail, request);
     }

--- a/api-server/src/main/java/com/huyeon/superspace/domain/board/document/FavoriteCategory.java
+++ b/api-server/src/main/java/com/huyeon/superspace/domain/board/document/FavoriteCategory.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import javax.persistence.Id;
+import java.util.LinkedList;
 import java.util.List;
 
 @Getter
@@ -15,9 +17,18 @@ import java.util.List;
 @AllArgsConstructor
 @Document(collection = "favorite_category")
 public class FavoriteCategory extends DocumentAudit {
+    @Id
+    private String id;
+
     private String userEmail;
 
     private String groupUrl;
 
     private List<String> categoryIds;
+
+    public FavoriteCategory(String userEmail, String groupUrl) {
+        this.userEmail = userEmail;
+        this.groupUrl = groupUrl;
+        this.categoryIds = new LinkedList<>();
+    }
 }

--- a/api-server/src/main/java/com/huyeon/superspace/domain/board/document/TempPost.java
+++ b/api-server/src/main/java/com/huyeon/superspace/domain/board/document/TempPost.java
@@ -62,10 +62,10 @@ public class TempPost extends DocumentAudit {
     @Getter
     @NoArgsConstructor
     static class TempContent {
-        private String markdown;
+        private String html;
 
         public TempContent(ContentDto contentDto) {
-            markdown = contentDto.getHtml();
+            html = contentDto.getHtml();
         }
     }
 }

--- a/api-server/src/main/java/com/huyeon/superspace/domain/board/service/NewCategoryService.java
+++ b/api-server/src/main/java/com/huyeon/superspace/domain/board/service/NewCategoryService.java
@@ -84,7 +84,7 @@ public class NewCategoryService {
 
     private FavoriteCategory findFavoriteByEmailAndUrl(String email, String groupUrl) {
         return favoriteRepository.findAllByUserEmailAndGroupUrl(email, groupUrl)
-                .orElse(new FavoriteCategory(email, groupUrl, new LinkedList<>()));
+                .orElse(new FavoriteCategory(email, groupUrl));
     }
 
     public List<CategoryDto> getCategoryList(String groupUrl) {

--- a/front-server/src/main/resources/static/css/board/board.css
+++ b/front-server/src/main/resources/static/css/board/board.css
@@ -63,6 +63,7 @@ label {
 }
 
 .board-delete {
+    padding: 3px 8px;
     transition: all 100ms ease-in 0s;
 }
 

--- a/front-server/src/main/resources/static/css/board/board.css
+++ b/front-server/src/main/resources/static/css/board/board.css
@@ -33,7 +33,6 @@ label {
 
 .scroll-frame {
     width: 100%;
-    height: calc(100% - 60px);
     position: relative;
     overflow: hidden;
 }

--- a/front-server/src/main/resources/static/css/community/community.css
+++ b/front-server/src/main/resources/static/css/community/community.css
@@ -26,12 +26,15 @@ a {
 }
 
 ul {
-    padding: 0 !important;
     margin: 0 !important;
 }
 
+.super-space-app__sidebar ul {
+    padding: 0 !important;
+}
+
 li {
-    list-style: none;
+    list-style: inherit;
 }
 
 label {

--- a/front-server/src/main/resources/static/css/community/community.css
+++ b/front-server/src/main/resources/static/css/community/community.css
@@ -467,13 +467,13 @@ label {
 .custom-modal {
     display: none;
     position: fixed;
-    top: 45%;
+    top: 50%;
     left: 50%;
-    transform: translate(-50%, -45%);
+    transform: translate(-50%, -50%);
     z-index: 9999;
     width: calc(95%);
     max-width: 450px;
-    max-height: 90%;
+    max-height: 70vh;
 }
 
 .custom-modal.wide-style {
@@ -493,8 +493,9 @@ label {
 }
 
 .custom-modal-wrapper {
+    max-height: 70vh;
     width: 100%;
-    position: absolute;
+    position: relative;
     border: 1px solid rgba(0, 0, 0, 30%);
     border-radius: 5px;
     background: white;

--- a/front-server/src/main/resources/static/js/board/board-util.js
+++ b/front-server/src/main/resources/static/js/board/board-util.js
@@ -11,7 +11,7 @@ function drawBoards(data) {
         drawEachItem(data)
     } else {
         for (let value of Object.values(data)) {
-            drawBoard(value);
+            drawEachItem(value);
         }
     }
 

--- a/front-server/src/main/resources/static/js/board/board-view.js
+++ b/front-server/src/main/resources/static/js/board/board-view.js
@@ -60,20 +60,15 @@ $(document).on('click', '#comment-toggle-btn', () => {
     }
 })
 
-$(document).on('click', '.js-comment-add-btn', () => {
+function registerComment() {
+    const url = "/api/comment";
     const request = {
         author: $('.comment-inbox-name').attr('id'),
         nickname: $(".comment-inbox-name").text(),
         body: $('.comment-inbox-text').val(),
-        groupUrl: groupUrl
+        groupUrl: groupUrl,
+        boardId: boardId
     };
-
-    registerComment(request);
-})
-
-function registerComment(request) {
-    const url = "/api/comment";
-    request.boardId = boardId;
 
     post(url, request)
         .then(res => res.text())

--- a/front-server/src/main/resources/static/js/board/board-view.js
+++ b/front-server/src/main/resources/static/js/board/board-view.js
@@ -1,6 +1,9 @@
 let boardId = pathname.slice(pathname.lastIndexOf("/") + 1);
 
 function pageRender() {
+    if ($(".app-footer").length === 0) {
+        $(".whole-scroll-section").css("max-height", "calc(100vh - 70px)");
+    }
     appendBoardLike();
     increaseViews();
 }

--- a/front-server/src/main/resources/static/js/board/board-view.js
+++ b/front-server/src/main/resources/static/js/board/board-view.js
@@ -16,7 +16,7 @@ function appendBoardLike() {
             $("#like-post-num").text(data.like);
 
             const $like = $("#like-post-heart");
-            if (data.checked) $like.addClass("like-color");
+            if (data.checked) $like.addClass("like-color").text("favorite");
             else $like.addClass("material-symbols-outlined");
 
             $("#viewer").show();

--- a/front-server/src/main/resources/static/js/board/board-view.js
+++ b/front-server/src/main/resources/static/js/board/board-view.js
@@ -32,6 +32,21 @@ function increaseViews() {
         })
 }
 
+function deleteBoard() {
+    if (!confirm("정말로 삭제하시겠습니까?")) {
+        return;
+    }
+
+    delWithoutBody("/api/board/" + boardId)
+        .then(() => {
+            location.href = "/community/" + groupUrl;
+        })
+        .catch(error => {
+            alert("삭제에 실패했습니다!");
+            console.error(error);
+        });
+}
+
 /*comment*/
 $(document).on('click', '#comment-toggle-btn', () => {
     const area = $('#comment-hide-area').get(0);

--- a/front-server/src/main/resources/static/js/category/category-manage.js
+++ b/front-server/src/main/resources/static/js/category/category-manage.js
@@ -362,6 +362,7 @@ function createCategoryGroupHTML() {
 //카테고리 선택 시 편집 모달 oepn
 $(document).on("click", "#sortable > li", (e) => {
     $("#modal-dimmed").show();
+    $("#modal").show();
     createEditCategoryModalHTML($(e.target));
 })
 

--- a/front-server/src/main/resources/static/js/community/community.js
+++ b/front-server/src/main/resources/static/js/community/community.js
@@ -70,12 +70,14 @@ function openSideBar() {
     onDimmed();
 }
 
-$(document).on('click', '.sidebar-mobile-dimmed', () => {
+$(document).on('click', '.sidebar-mobile-dimmed', closeSideBar)
+
+function closeSideBar() {
     $(".super-space-app__sidebar")
         .addClass("closed")
         .removeClass("open");
     $(".sidebar-mobile-dimmed").hide();
-})
+}
 
 let sidebarHeaderSize;
 
@@ -156,6 +158,7 @@ $(".sidebar-header .expand").click((e) => {
 })
 
 function openInviteModal() {
+    if ($(".sidebar-mobile-dimmed").css("display") === "block") closeSideBar();
     $("#modal-dimmed").show();
 
     const $element = $(`

--- a/front-server/src/main/resources/static/js/community/sse_noty.js
+++ b/front-server/src/main/resources/static/js/community/sse_noty.js
@@ -83,7 +83,7 @@ function addOnClick($element, noty) {
     const canRedirectList = ["NOTICE", "BOARD_NEW_COMMENT"];
 
     if (canRedirectList.includes(noty.type)) {
-        $element.attr("onclick", `moveToBoard("${noty.url}")`) //게시글로 이동
+        $element.attr("onclick", `moveToBoardAndRead(this)`) //게시글로 이동
             .addClass("pointer-hover");
     } else if (noty.type === "GROUP_INVITE" && !noty.read) { //그룹 초대 알림을 읽지않았으면
         $element.attr("onclick", `openJoinModal(this)`) //모달창 OPEN 가능
@@ -92,7 +92,11 @@ function addOnClick($element, noty) {
     }
 }
 
-function moveToBoard(url) {
+function moveToBoardAndRead(element) {
+    const $noty = $(element);
+    const url = $noty.data("url");
+    const notyId = $noty.attr('id').slice("noty_".length);
+    setRead(notyId);
     location.href = url;
 }
 

--- a/front-server/src/main/resources/static/js/community/sse_noty.js
+++ b/front-server/src/main/resources/static/js/community/sse_noty.js
@@ -254,7 +254,7 @@ function requestSetRead(request) {
 }
 
 //미확인 알림창 설정
-function initNotyDialog($element) {
+function initNotyDialog() {
     const $modal = $(`
         <div class="custom-modal-wrapper">
             <div class="custom-modal-inner">

--- a/front-server/src/main/resources/static/js/community/sse_noty.js
+++ b/front-server/src/main/resources/static/js/community/sse_noty.js
@@ -240,6 +240,8 @@ function setReadAll() {
 
     if (request.length !== 0) {
         requestSetRead(request);
+        $("#noty-dialog li").remove();
+        $("#js-noty-count").text(0);
         $(".js-noty-empty").attr('hidden', false);
         localStorage.setItem("curNotyNum", "0");
     }

--- a/front-server/src/main/resources/static/js/community/sse_noty.js
+++ b/front-server/src/main/resources/static/js/community/sse_noty.js
@@ -13,6 +13,7 @@ function getUnreadNoty() {
     get("/api/noty/unread")
         .then(res => res.json())
         .then(data => {
+            localStorage.setItem("curNotyNum", data.length);
             $("#js-noty-count").text(data.length);
 
             if (data.length !== 0) {
@@ -44,6 +45,7 @@ function addNotyListener(eventSource) {
             const $noty = $('#js-noty-count');
             const current = parseInt($noty.text());
             $noty.text(current + 1);
+            localStorage.setItem("curNotyNum", (current + 1).toString());
 
             $("#noty-dialog").prepend(createNotyHTML(data));
 
@@ -219,6 +221,8 @@ function setRead(id) {
     const now = parseInt($noty.text()) - 1;
     $noty.text(now);
 
+    localStorage.setItem("curNotyNum", now.toString());
+
     if (now === 0) $(".js-noty-empty").attr('hidden', false);
 }
 
@@ -233,6 +237,7 @@ function setReadAll() {
     if (request.length !== 0) {
         requestSetRead(request);
         $(".js-noty-empty").attr('hidden', false);
+        localStorage.setItem("curNotyNum", "0");
     }
 }
 

--- a/front-server/src/main/resources/static/js/group/member.js
+++ b/front-server/src/main/resources/static/js/group/member.js
@@ -222,10 +222,10 @@ function changeGrade() {
 
 function renderGradeModal() {
     const $element = $(`
-        <div class="custom-modal-wrapper">
+        <div class="custom-modal-wrapper" style="overflow: initial !important;">
             <div class="custom-modal-inner">
                 <div class="custom-modal-title">변경할 등급을 선택하세요</div>
-                <div class="custom-modal-main">
+                <div class="custom-modal-main" style="align-items: center">
                     <div class="group-custom-select" onclick="openOptions()">
                         <span>등급 단계</span>
                         <i class="material-icons-outlined md-16">unfold_more</i>

--- a/front-server/src/main/resources/static/js/group/member.js
+++ b/front-server/src/main/resources/static/js/group/member.js
@@ -91,9 +91,12 @@ function createBoardReqAPI(tab) {
 }
 
 function currentTab() {
-    const tab = new URLSearchParams(location.search).get("tab");
+    let tab = new URLSearchParams(location.search).get("tab");
+    if(tab == null) tab = "📝작성한 글";
+
     const $tab = $(`.member-menu span:contains(${tab})`);
     $tab.addClass("selected");
+
     let type = $tab.attr("id");
     if (type === undefined) type = "write";
     return type;

--- a/front-server/src/main/resources/static/js/util/fetch.js
+++ b/front-server/src/main/resources/static/js/util/fetch.js
@@ -8,6 +8,11 @@ let accessToken = null;
 $(function () {
     if (isMainPage()) return;
 
+    const num = localStorage.getItem("curNotyNum");
+    if (num != null) {
+        $("#js-noty-count").text(num);
+    }
+    
     init()
         .then(() => console.log("[Page Initiation Success]"));
 });

--- a/front-server/src/main/resources/templates/fragments/header.html
+++ b/front-server/src/main/resources/templates/fragments/header.html
@@ -4,8 +4,8 @@
     <div class="header-box">
         <div class="header-left">
             <i id="js-sidebar-expand-btn" class="material-icons-outlined sidebar-expand" onclick="openSideBar()">menu</i>
-            <div class="group-name" th:classappend="${sideBar.member.id == 'anonymous' ? 'anonymous' : ''}"
-                 th:text="${appHeader.groupName}" th:attr="onclick=${sideBar.member.id == 'anonymous' ? '' : 'moveToGroupMain()'}">GROUP NAME
+            <div class="group-name" th:classappend="${appHeader.groupName == '그룹을 선택하세요.' ? 'anonymous' : ''}"
+                 th:text="${appHeader.groupName}" th:attr="onclick=${appHeader.groupName == '그룹을 선택하세요.' ? '' : 'moveToGroupMain()'}">GROUP NAME
             </div>
         </div>
         <div class="header-right">

--- a/front-server/src/main/resources/templates/fragments/sidebar.html
+++ b/front-server/src/main/resources/templates/fragments/sidebar.html
@@ -94,13 +94,13 @@
                                 <span>기본 카테고리</span>
                                 <div class="default-category">
                                     <div class="sidebar-elements pointer-hover">
-                                        <span onclick="moveToMainPage(this)">🔥한눈에 보기</span>
+                                        <span style="width: 100%" onclick="moveToMainPage(this)">🔥한눈에 보기</span>
                                     </div>
                                     <div class="sidebar-elements pointer-hover">
-                                        <span onclick="moveToMainPage(this)">📝전체 게시글</span>
+                                        <span style="width: 100%" onclick="moveToMainPage(this)">📝전체 게시글</span>
                                     </div>
                                     <div class="sidebar-elements pointer-hover">
-                                        <span onclick="moveToMainPage(this)">⭐공지사항</span>
+                                        <span style="width: 100%" onclick="moveToMainPage(this)">⭐공지사항</span>
                                     </div>
                                 </div>
                                 <span>일반 카테고리</span>

--- a/front-server/src/main/resources/templates/pages/board/board-editor.html
+++ b/front-server/src/main/resources/templates/pages/board/board-editor.html
@@ -48,13 +48,6 @@
                         </select>
                     </label>
                 </div>
-                <div class="header-elements">
-                    <label id="tags" class="flex-horizon-center">
-                        <span class="name mr-2">태그</span>
-                        <div class="flex-horizon-center"></div>
-                        <input class="empty tag" placeholder="#태그 추가">
-                    </label>
-                </div>
             </div>
             <div class="mt-3">
                 <div id="ck5-editor-toolbar"></div>

--- a/front-server/src/main/resources/templates/pages/board/board-editor.html
+++ b/front-server/src/main/resources/templates/pages/board/board-editor.html
@@ -30,6 +30,7 @@
                             <option th:each="category : ${sideBar.categories}"
                                     th:value="${category.name}"
                                     th:attr="data-category-id=${category.id}"
+                                    th:unless="${category.type == 'CATEGORY_GROUP'}"
                                     th:text="${category.name}">카테고리
                             </option>
                         </select>

--- a/front-server/src/main/resources/templates/pages/board/board-modify.html
+++ b/front-server/src/main/resources/templates/pages/board/board-modify.html
@@ -12,7 +12,6 @@
             <div class="board__header">
                 <div class="flex-end">
                     <div>
-                        <button type="button" class="simple-button board-history">변경이력</button>
                         <button type="button" class="simple-button board-delete" onclick="deleteBoard()">삭제</button>
                     </div>
                 </div>
@@ -59,16 +58,6 @@
                                     value="COMPLETE">COMPLETE
                             </option>
                         </select>
-                    </label>
-                </div>
-                <div class="header-elements">
-                    <label id="tags" class="flex-horizon-center">
-                        <span class="name mr-2">태그</span>
-                        <div class="tag-wrapper flex-horizon-center" th:each="tag : ${board.tags}">
-                            <input class="tag" th:value="|${tag}|">
-                            <i class="pointer material-icons-outlined delete md-16 gray">delete</i>
-                        </div>
-                        <input class="empty tag" placeholder="#태그 추가">
                     </label>
                 </div>
             </div>

--- a/front-server/src/main/resources/templates/pages/board/board-viewer.html
+++ b/front-server/src/main/resources/templates/pages/board/board-viewer.html
@@ -65,8 +65,11 @@
                     <div id="comment-hide-area" class="comment-list" hidden>
                         <li th:each="comment : ${comments}" th:id="|comment_${comment.id}|" class="comment-item">
                             <div class="comment-area">
-                                <div th:id="${comment.author}" class="comment-nick-box" th:text="${comment.nickname}">nickname</div>
-                                <div class="comment-text-box" th:utext="${comment.body.replaceAll('\n', '<br>')}">댓글</div>
+                                <div th:id="${comment.author}" class="comment-nick-box" th:text="${comment.nickname}">
+                                    nickname
+                                </div>
+                                <div class="comment-text-box" th:utext="${comment.body.replaceAll('\n', '<br>')}">댓글
+                                </div>
                                 <div class="comment-info-box">
                                     <span class="comment-info-date"
                                           th:text="${comment.lastUpdate}">2023.01.08 16:45</span>
@@ -80,12 +83,19 @@
                     </div>
                     <div class="comment-writer">
                         <div class="comment-inbox">
-                            <div class="comment-inbox-name" th:id="${sideBar.member.email}" th:text="${sideBar.member.nickname}">사용자명</div>
-                            <textarea class="comment-inbox-text" placeholder="댓글을 남겨보세요."></textarea>
+                            <div class="comment-inbox-name" th:id="${sideBar.member.email}"
+                                 th:text="${sideBar.member.nickname}">사용자명
+                            </div>
+                            <textarea class="comment-inbox-text"
+                                      th:placeholder="${sideBar.member.id == 'anonymous' ? '로그인이 필요한 서비스 입니다.' : '댓글을 남겨보세요.'}"
+                                      th:readonly="${sideBar.member.id == 'anonymous' ? 'readonly' : 'false'}"></textarea>
                         </div>
                         <div class="comment-attach">
                             <div class="comment-register">
-                                <button type="button" class="js-comment-add-btn simple-button">등록</button>
+                                <button type="button" class="simple-button"
+                                        th:attr="onclick=${sideBar.member.id == 'anonymous' ? '' : 'registerComment()'}">
+                                    등록
+                                </button>
                             </div>
                         </div>
                     </div>

--- a/front-server/src/main/resources/templates/pages/group/creategroup.html
+++ b/front-server/src/main/resources/templates/pages/group/creategroup.html
@@ -31,8 +31,8 @@
                 <input class="form-control"
                        id="js-group-url"
                        placeholder="사용할 URL 경로명을 입력하세요.">
-                <span class="custom-input-label">https://conmoto.site/community/{여기에 들어갈 URL}</span>
-                <span class="custom-input-label">해당 주소가 그룹의 고유 주소가 됩니다.</span>
+                <p class="custom-input-label">https://conmoto.site/community/{여기에 들어갈 URL}</p>
+                <p class="custom-input-label">해당 주소가 그룹의 고유 주소가 됩니다.</p>
             </div>
             <div class="element-area">
                 <span class="custom-input-label">내 닉네임</span>


### PR DESCRIPTION
1. 비로그인 시 뷰어페이지 헤더 그룹이동 안됨 …OK
2. 뷰어 푸터없을때 아래 짤린것처럼 보임 …OK
3. 알림 리다이렉트 안됨(id가 null임) …OK
4. 알림 모두읽음처리시 알림 안사라지고 숫자 0으로 안바뀜 …OK
5. 임시저장 불러오기 실패 …OK
6. 에디터페이지에서는 미확인알림 로딩안됨 …OK
7. 내계정 클릭시 화면짤림 …OK
8. 내활동 클릭시 처음에 아무것도 안뜸(탭 눌러야 나옴) …OK
9. 그룹생성페이지 - 설명 <br>필요 …OK
10. 그룹가입, 멤버 등급변경 모달 창 안보임 …OK
11. 한눈에보기 undefined (렌더링실패) …OK
13.태그 폭 자동조절 버그 (기능 삭제예정) …OK
14. 게시글 삭제안됨 …OK
15. 변경이력 안열림 (삭제예정) …OK
16. 좋아요를했음에도 최초렌더링시 색깔만 빨간색인 빈하트가 나옴 …OK
17. 들여쓰기한 카테고리 터치 잘안됨(폭 문제) …OK
18. 알림 읽음처리 안됨 …OK
19. 카테고리 관리페이지 - 카테고리 상세창 안열림 …OK
20. 모바일에서 그룹초대창 부자연스러움 (사이드바와 겹침) …OK
21. [Hotfix] 비로그인시 댓글달림 …OK
23. 즐겨찾기 2회이상 클릭 시 500 에러 …OK